### PR TITLE
IAA Change #2 - Changes IAA flavourtext, forces them to act in murderboneless secrecy

### DIFF
--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -236,14 +236,16 @@
 /datum/antagonist/traitor/internal_affairs/proc/greet_iaa()
 	var/crime = pick("distribution of contraband" , "unauthorized erotic action on duty", "embezzlement", "piloting under the influence", "dereliction of duty", "syndicate collaboration", "mutiny", "multiple homicides", "corporate espionage", "receiving bribes", "malpractice", "worship of prohibited life forms", "possession of profane texts", "murder", "arson", "insulting their manager", "grand theft", "conspiracy", "attempting to unionize", "vandalism", "gross incompetence")
 
+	var/murderbone_phrasing = "<B><font size=5 color=red>While you have a license to kill your targets, you must absolutely maintain your secrecy and minimize all collatoral damage & loss of crew. If you are found, you must kill yourself to maintain the secrecy of your operation. Failure to do so may secure you a much more violent end sent from [syndicate ? "Syndicate" : "Central"] Command.</font></B>"
+
 	to_chat(owner.current, "<span class='userdanger'>You are the [special_role].</span>")
 	if(syndicate)
 		to_chat(owner.current, "<span class='userdanger'>Your target has been framed for [crime], and you have been tasked with eliminating them to prevent them defending themselves in court.</span>")
-		to_chat(owner.current, "<B><font size=5 color=red>Any damage you cause will further increase tensions between The Syndicate and Nanotrasen, so you should limit collateral damage.</font></B>") //yogs - murderbone rule exists, apparently
+		to_chat(owner.current, murderbone_phrasing)
 		to_chat(owner.current, "<span class='userdanger'> You have been provided with a standard uplink to accomplish your task. </span>")
 	else
 		to_chat(owner.current, "<span class='userdanger'>Your target is suspected of [crime], and you have been tasked with eliminating them by any means necessary to avoid a costly and embarrassing public trial.</span>")
-		to_chat(owner.current, "<B><font size=5 color=red>While you have a license to kill, unneeded property damage or loss of employee life will lead to your contract being terminated.</font></B>")
+		to_chat(owner.current, murderbone_phrasing)
 		to_chat(owner.current, "<span class='userdanger'>For the sake of plausible deniability, you have been equipped with an array of captured Syndicate weaponry available via uplink.</span>")
 
 	to_chat(owner.current, "<span class='userdanger'>Finally, watch your back. Your target has friends in high places, and intel suggests someone may have taken out a contract of their own to protect them.</span>")


### PR DESCRIPTION
I'm OK with rewriting it further if someone points out an alternative wording to what I gave; it's just what I came up with based on what MasterPenguin & al said in #staff-council.

Changelog
🆑 Altoids
tweak: IAA agents must now actually bother to be secret agents, as per a change in Internal Affairs division guidelines.
/🆑
