### PR TITLE
Makes Particle Accelerators inform you of what part it cannot find when scanning

### DIFF
--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -180,7 +180,7 @@
 	T = get_step(T,dir)
 	T = get_step(T,dir)
 	if(!check_part(T, /obj/structure/particle_accelerator/power_box))
-		error_message = "Unable to find the Power Box!"
+		error_message = "Unable to find the power box!"
 		return FALSE
 	T = get_step(T,dir)
 	if(!check_part(T, /obj/structure/particle_accelerator/particle_emitter/center))

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -184,7 +184,7 @@
 		return FALSE
 	T = get_step(T,dir)
 	if(!check_part(T, /obj/structure/particle_accelerator/particle_emitter/center))
-		error_message = "Unable to find the Central Emitter!"
+		error_message = "Unable to find the central emitter!"
 		return FALSE
 	T = get_step(T,ldir)
 	if(!check_part(T, /obj/structure/particle_accelerator/particle_emitter/left))

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -171,7 +171,7 @@
 	//start-trot
 	T = get_step(T,rdir)
 	if(!check_part(T, /obj/structure/particle_accelerator/fuel_chamber))
-				error_message = "Unable to find any parts!"
+		error_message = "Unable to find the Fuel Chamber!"
 		return FALSE
 	T = get_step(T,odir)
 	if(!check_part(T, /obj/structure/particle_accelerator/end_cap))

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -188,7 +188,7 @@
 		return FALSE
 	T = get_step(T,ldir)
 	if(!check_part(T, /obj/structure/particle_accelerator/particle_emitter/left))
-		error_message = "Unable to find the Leftside Emitter!"
+		error_message = "Unable to find the left-side emitter!"
 		return FALSE
 	T = get_step(T,rdir)
 	T = get_step(T,rdir)

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -193,7 +193,7 @@
 	T = get_step(T,rdir)
 	T = get_step(T,rdir)
 	if(!check_part(T, /obj/structure/particle_accelerator/particle_emitter/right))
-		error_message = "Unable to find the Rightside Emitter!"
+		error_message = "Unable to find the right-side emitter!"
 		return FALSE
 	//end-trot
 	assembled = TRUE

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -171,7 +171,7 @@
 	//start-trot
 	T = get_step(T,rdir)
 	if(!check_part(T, /obj/structure/particle_accelerator/fuel_chamber))
-		error_message = "Unable to find the Fuel Chamber!"
+				error_message = "Unable to find any parts!"
 		return FALSE
 	T = get_step(T,odir)
 	if(!check_part(T, /obj/structure/particle_accelerator/end_cap))

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -175,7 +175,7 @@
 		return FALSE
 	T = get_step(T,odir)
 	if(!check_part(T, /obj/structure/particle_accelerator/end_cap))
-		error_message = "Unable to find the End Cap!"
+		error_message = "Unable to find the end cap!"
 		return FALSE
 	T = get_step(T,dir)
 	T = get_step(T,dir)

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -17,6 +17,7 @@
 	var/active = FALSE
 	var/strength = 0
 	var/powered = FALSE
+	var/error_message //Trot - The error to display when assembly does not work out
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 
 /obj/machinery/particle_accelerator/control_box/Initialize()
@@ -167,27 +168,34 @@
 	setDir(F.dir)
 	connected_parts.Cut()
 
+	//start-trot
 	T = get_step(T,rdir)
 	if(!check_part(T, /obj/structure/particle_accelerator/fuel_chamber))
+		error_message = "Unable to find the Fuel Chamber!"
 		return FALSE
 	T = get_step(T,odir)
 	if(!check_part(T, /obj/structure/particle_accelerator/end_cap))
+		error_message = "Unable to find the End Cap!"
 		return FALSE
 	T = get_step(T,dir)
 	T = get_step(T,dir)
 	if(!check_part(T, /obj/structure/particle_accelerator/power_box))
+		error_message = "Unable to find the Power Box!"
 		return FALSE
 	T = get_step(T,dir)
 	if(!check_part(T, /obj/structure/particle_accelerator/particle_emitter/center))
+		error_message = "Unable to find the Central Emitter!"
 		return FALSE
 	T = get_step(T,ldir)
 	if(!check_part(T, /obj/structure/particle_accelerator/particle_emitter/left))
+		error_message = "Unable to find the Leftside Emitter!"
 		return FALSE
 	T = get_step(T,rdir)
 	T = get_step(T,rdir)
 	if(!check_part(T, /obj/structure/particle_accelerator/particle_emitter/right))
+		error_message = "Unable to find the Rightside Emitter!"
 		return FALSE
-
+	//end-trot
 	assembled = TRUE
 	critical_machine = TRUE	//Only counts if the PA is actually assembled.
 	return TRUE
@@ -243,7 +251,7 @@
 	dat += "<A href='?src=[REF(src)];close=1'>Close</A><BR><BR>"
 	dat += "<h3>Status</h3>"
 	if(!assembled)
-		dat += "Unable to detect all parts!<BR>"
+		dat += "[error_message]<BR>" //trot
 		dat += "<A href='?src=[REF(src)];scan=1'>Run Scan</A><BR><BR>"
 	else
 		dat += "All parts in place.<BR><BR>"

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -171,7 +171,7 @@
 	//start-trot
 	T = get_step(T,rdir)
 	if(!check_part(T, /obj/structure/particle_accelerator/fuel_chamber))
-		error_message = "Unable to find the Fuel Chamber!"
+		error_message = "Unable to find any parts!" // Described as such since scanning implicitly blanks the known parts up above, and this is a sequential returney thing, so not finding the first part means none are known now
 		return FALSE
 	T = get_step(T,odir)
 	if(!check_part(T, /obj/structure/particle_accelerator/end_cap))


### PR DESCRIPTION
## Overview
This is in general supposed to be a nice Quality-of-Life change to make it slightly easier to find mysterious issues with your PA setup. Buffs shitty engineers.

#### Changelog
:cl:  Altoids
tweak: PAs will now inform you of exactly what part it was unable to find.
/:cl:
