### PR TITLE
Fix Travis BSQL build script after import of Linux libBSQL

### DIFF
--- a/tools/travis/build_bsql.sh
+++ b/tools/travis/build_bsql.sh
@@ -18,4 +18,4 @@ cmake .. -DMARIA_LIBRARY=/usr/lib/i386-linux-gnu/libmariadb.so
 make
 
 mkdir -p ~/.byond/bin
-ln -s $PWD/src/BSQL/libBSQL.so ../../libBSQL.so
+ln -s $PWD/src/BSQL/libBSQL.so ~/.byond/bin


### PR DESCRIPTION
After the introduction of Linux BSQL, Travis began to have builds fail due to an oversight in the BSQL build script, which directly linked the newly built library to a symlink in the root of the repository. This conflicted with the import of Linux BSQL. I have changed it to follow the pattern in the other scripts, which instead link it to BYOND's local binary directory.